### PR TITLE
Use expanded directory names for repo folders

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -213,6 +213,14 @@ function Get-Drive( [string] $path ) {
     }
 }
 
+function Is-Git( $dir ) {
+    return Get-ChildItem -Path $dir.FullName -force .git
+}
+
+function Is-Hg( $dir ) {
+    return Get-ChildItem -Path $dir.FullName -force .hg
+}
+
 
 function Shorten-Path([string] $path) { 
 
@@ -222,7 +230,7 @@ function Shorten-Path([string] $path) {
     while($dir.Parent) {
 
         # Prepend to list
-        if( $result.length -eq 0 ) {
+        if( (Is-Git $dir) -Or (Is-Hg $dir) -Or ($result.length -eq 0) ) {
             $result = ,$dir.Name + $result
         } else {
             $result = ,$dir.Name.Substring(0, $SHORT_FOLDER_NAME_SIZE) + $result

--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -28,6 +28,8 @@ $FANCY_X = [char]10008
 $DRIVE_DEFAULT_COLOR = "gray"
 $GIT_COLOR_DEFAULT = "green"
 
+$SHORT_FOLDER_NAME_SIZE = 3
+
 $colors = @{}
 $colors["blue"] = ([ConsoleColor]::Cyan, [ConsoleColor]::DarkBlue)
 $colors["green"] = ([ConsoleColor]::Green, [ConsoleColor]::DarkGreen)
@@ -213,20 +215,24 @@ function Get-Drive( [string] $path ) {
 
 
 function Shorten-Path([string] $path) { 
-    $loc = $path.Replace($HOME, '~') 
 
+    $result = @()
+    $dir = Get-Item $path
 
-    # remove prefix for UNC paths 
-    $loc = $loc -replace '^[^:]+::', '' 
+    while($dir.Parent) {
 
+        # Prepend to list
+        if( $result.length -eq 0 ) {
+            $result = ,$dir.Name + $result
+        } else {
+            $result = ,$dir.Name.Substring(0, $SHORT_FOLDER_NAME_SIZE) + $result
+        }
 
-    $drive = Get-Drive (Get-Location).Path
-    $loc = $loc.TrimStart( $drive )
+        $dir = $dir.Parent
 
+    }
 
-    # make path shorter like tabs in Vim, 
-    # handle paths starting with \\ and . correctly 
-    return ($loc -replace '\\(\.?)([^\\]{3})[^\\]*(?=\\)','\$1$2') 
+    return "\" + ($result -join "\")
 }
 
 

--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -223,7 +223,7 @@ function Shorten-Path([string] $path) {
     $result = @()
     $dir = Get-Item $path
 
-    while($dir.Parent) {
+    while( ($dir.Parent) -And ($dir.FullName -ne $HOME) ) {
 
         if( (Is-VCSRoot $dir) -Or ($result.length -eq 0) ) {
             $result = ,$dir.Name + $result

--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -213,14 +213,10 @@ function Get-Drive( [string] $path ) {
     }
 }
 
-function Is-Git( $dir ) {
-    return Get-ChildItem -Path $dir.FullName -force .git
+function Is-VCSRoot( $dir ) {
+    return (Get-ChildItem -Path $dir.FullName -force .git) `
+       -Or (Get-ChildItem -Path $dir.FullName -force .hg)
 }
-
-function Is-Hg( $dir ) {
-    return Get-ChildItem -Path $dir.FullName -force .hg
-}
-
 
 function Shorten-Path([string] $path) { 
 
@@ -230,7 +226,7 @@ function Shorten-Path([string] $path) {
     while($dir.Parent) {
 
         # Prepend to list
-        if( (Is-Git $dir) -Or (Is-Hg $dir) -Or ($result.length -eq 0) ) {
+        if( (Is-VCSRoot $dir) -Or ($result.length -eq 0) ) {
             $result = ,$dir.Name + $result
         } else {
             $result = ,$dir.Name.Substring(0, $SHORT_FOLDER_NAME_SIZE) + $result

--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -81,8 +81,8 @@ function Prompt {
     
     switch ($drive){
         "\\" { $driveColor = "magenta" }
-        "C:" { $driveColor = "blue" }
-        "~"  { $driveColor = "blue"}
+        "C:\" { $driveColor = "blue" }
+        "~\"  { $driveColor = "blue"}
     }
 
     $lastColor = $driveColor
@@ -205,11 +205,11 @@ function Vanilla-Window{
 
 function Get-Drive( [string] $path ) {
     if( $path.StartsWith( $HOME ) ) {
-        return "~"
+        return "~\"
     } elseif( $path.StartsWith( "Microsoft.PowerShell.Core" ) ){
         return "\\"
     } else {
-        return $path.split( "\" )[0]
+        return (Get-Item $path).Root
     }
 }
 
@@ -225,7 +225,6 @@ function Shorten-Path([string] $path) {
 
     while($dir.Parent) {
 
-        # Prepend to list
         if( (Is-VCSRoot $dir) -Or ($result.length -eq 0) ) {
             $result = ,$dir.Name + $result
         } else {
@@ -233,10 +232,9 @@ function Shorten-Path([string] $path) {
         }
 
         $dir = $dir.Parent
-
     }
 
-    return "\" + ($result -join "\")
+    return $result -join "\"
 }
 
 


### PR DESCRIPTION
This change traverses the actual path to build the prompt, and leaves 
the names of directories that are Git or Mercurial repositories at their 
full length.
