### PR TITLE
Add exception trap to force exit code 1

### DIFF
--- a/test.ps1
+++ b/test.ps1
@@ -1,3 +1,9 @@
+trap #trap exceptions and force failure
+{
+    write-output $_
+    exit 1
+}
+
 Import-Module Pester
 Set-StrictMode -Version Latest
 Import-Module agent-api -ErrorAction SilentlyContinue


### PR DESCRIPTION
Just as it says. Fixes an issue i noticed while working on the regression where failures in the tests themselves didn't cause a build failure if they made the tests break so hard the test system gave up.
